### PR TITLE
Fixed build for apps using Dagger

### DIFF
--- a/rxandroidble/build.gradle
+++ b/rxandroidble/build.gradle
@@ -42,6 +42,13 @@ android {
     }
 
     preBuild.dependsOn 'checkstyle'
+
+    packagingOptions {
+        // Dagger 2.25.4 introduced a file for tracking purposes. This can break apps using Dagger.
+        // See https://github.com/dariuszseweryn/RxAndroidBle/issues/789
+        // Source https://github.com/google/dagger/commit/709098caaf4c7124f5e5313c1aa9ab34fced0031
+        excludes = ['**/com.google.dagger_dagger.version']
+    }
 }
 
 androidGroovy {


### PR DESCRIPTION
Dagger in 2.25.4 introduced a tracking file ('META-INF/com.google.dagger_dagger.version') which is published with the archive. If the file is in a library and the app also uses Dagger it can break a build by default because the file is already there.

Fixes #789 