### PR TITLE
Added granted permissions cache in CheckerPermission.

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/CheckerPermission.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/CheckerPermission.java
@@ -6,12 +6,16 @@ import android.os.Process;
 
 import com.polidea.rxandroidble2.ClientScope;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import bleshadow.javax.inject.Inject;
 
 @ClientScope
 public class CheckerPermission {
 
     private final Context context;
+    private final Set<String> grantedPermissions = new HashSet<>();
 
     @Inject
     CheckerPermission(Context context) {
@@ -37,6 +41,16 @@ public class CheckerPermission {
             throw new IllegalArgumentException("permission is null");
         }
 
-        return context.checkPermission(permission, Process.myPid(), Process.myUid()) == PackageManager.PERMISSION_GRANTED;
+        if (grantedPermissions.contains(permission)) {
+            return true;
+        }
+
+        boolean isGranted = context.checkPermission(permission, Process.myPid(), Process.myUid()) == PackageManager.PERMISSION_GRANTED;
+
+        if (isGranted) {
+            grantedPermissions.add(permission);
+        }
+
+        return isGranted;
     }
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/CheckerPermissionTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/CheckerPermissionTest.groovy
@@ -1,0 +1,47 @@
+package com.polidea.rxandroidble2.internal.util
+
+import android.content.Context
+import android.content.pm.PackageManager
+import spock.lang.Specification
+
+class CheckerPermissionTest extends Specification {
+
+    String testPermissionString = "random.package.RANDOM_PERMISSION"
+    def testPermissionArray = new String[] { testPermissionString }
+    def mockContext = Mock Context
+    CheckerPermission objectUnderTest
+
+    def "should cache granted permissions"() {
+
+        given:
+        objectUnderTest = new CheckerPermission(mockContext)
+
+        when:
+        def result0 = objectUnderTest.isAnyPermissionGranted(testPermissionArray)
+        def result1 = objectUnderTest.isAnyPermissionGranted(testPermissionArray)
+
+        then:
+        1 * mockContext.checkPermission(testPermissionString, _, _) >> PackageManager.PERMISSION_GRANTED
+
+        and:
+        result0
+        result1
+    }
+
+    def "should call context each time if permission is not granted"() {
+
+        given:
+        objectUnderTest = new CheckerPermission(mockContext)
+
+        when:
+        def result0 = objectUnderTest.isAnyPermissionGranted(testPermissionArray)
+        def result1 = objectUnderTest.isAnyPermissionGranted(testPermissionArray)
+
+        then:
+        2 * mockContext.checkPermission(testPermissionString, _, _) >> PackageManager.PERMISSION_DENIED
+
+        and:
+        !result0
+        !result1
+    }
+}

--- a/rxandroidble/src/test/java/android/content/Context.java
+++ b/rxandroidble/src/test/java/android/content/Context.java
@@ -12,5 +12,6 @@ public abstract class Context {
         public abstract ContentResolver getContentResolver();
         public abstract Intent registerReceiver(BroadcastReceiver receiver, IntentFilter intentFilter);
         public abstract void unregisterReceiver(BroadcastReceiver receiver);
+        public abstract int checkPermission(String permission, int pid, int uid);
 
 }


### PR DESCRIPTION
The cache should help with much more frequent permission checks in case of using `RxBleDevice#toString()`. After the permission is granted no more calls to `Context#checkPermission(String, int, int)` will be made until the client is recreated.