### PR TITLE
Fix maximal supported MTU on Android 13

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleConnection.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleConnection.java
@@ -56,12 +56,14 @@ public interface RxBleConnection {
     int GATT_MTU_MINIMUM = 23;
 
     /**
-     * Even though the maximum supported value for MTU Negotiation (Maximum Transfer Unit) on Android OS is 517
+     * The maximum properly supported value for MTU (Maximum Transfer Unit) used by a bluetooth connection on Android OS.
+     * <p>The theoretical maximum value for MTU Negotiation on Android OS is 517
      * (https://cs.android.com/android/platform/superproject/+/master:packages/modules/Bluetooth/system/stack/include/gatt_api.h;l=244;drc=1918034a0730839c7a07b1260b1ab74b80d6b4e6)
      * the real maximal supported MTU is 515 since the buffer size is capped on 512 bytes = 515 - GATT_READ_MTU_OVERHEAD
      * (https://cs.android.com/android/platform/superproject/+/master:packages/modules/Bluetooth/system/stack/include/gatt_api.h;l=250;drc=1918034a0730839c7a07b1260b1ab74b80d6b4e6;bpv=1;bpt=1)
-     *
-     * NOTE: before Android 13 the effective maximal supported MTU was 517
+     * <p>
+     * <p>NOTE: before Android 13 (API 33) the maximal properly supported MTU was 517
+     * see https://android.googlesource.com/platform/external/bluetooth/bluedroid/+/android-5.1.0_r1/stack/include/gatt_api.h#119
      */
     int GATT_MTU_MAXIMUM = 515;
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleConnection.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleConnection.java
@@ -56,10 +56,15 @@ public interface RxBleConnection {
     int GATT_MTU_MINIMUM = 23;
 
     /**
-     * The maximum supported value for MTU (Maximum Transfer Unit) used by a bluetooth connection on Android OS.
-     * https://android.googlesource.com/platform/external/bluetooth/bluedroid/+/android-5.1.0_r1/stack/include/gatt_api.h#119
+     * Even though the maximum supported value for MTU Negotiation (Maximum Transfer Unit) on Android OS is 517
+     * (https://cs.android.com/android/platform/superproject/+/master:packages/modules/Bluetooth/system/stack/include/gatt_api.h;l=244;drc=1918034a0730839c7a07b1260b1ab74b80d6b4e6)
+     * the real maximal supported MTU is 515 since the buffer size is capped on 512 bytes = 515 - GATT_READ_MTU_OVERHEAD
+     * (https://cs.android.com/android/platform/superproject/+/master:packages/modules/Bluetooth/system/stack/include/gatt_api.h;l=250;drc=1918034a0730839c7a07b1260b1ab74b80d6b4e6;bpv=1;bpt=1)
+     *
+     * NOTE: before Android 13 the effective maximal supported MTU was 517
      */
-    int GATT_MTU_MAXIMUM = 517;
+    int GATT_MTU_MAXIMUM = 515;
+
 
     /**
      * Description of correct values of connection priority


### PR DESCRIPTION
Hello @dariuszseweryn,

since Android 13 the real maximal supported MTU by Android is 515.

Even though in Android source code the [GATT_MAX_MTU_SIZE](https://cs.android.com/android/platform/superproject/+/master:packages/modules/Bluetooth/system/stack/include/gatt_api.h;l=244;drc=1918034a0730839c7a07b1260b1ab74b80d6b4e6) is still set to 517, the data buffer size [GAT_MAX_ATTR_LEN](https://cs.android.com/android/platform/superproject/+/master:packages/modules/Bluetooth/system/stack/include/gatt_api.h;l=250;drc=1918034a0730839c7a07b1260b1ab74b80d6b4e6;bpv=1;bpt=1) is now capped at 512 bytes.

It leads to the situation when Android allows you to negotiate MTU 517, [but it drops all the packets with data larger then 512 bytes](https://cs.android.com/android/platform/superproject/+/master:packages/modules/Bluetooth/system/stack/gatt/gatt_cl.cc;l=687?q=GATT_MAX_ATTR_LEN)

Here is the [commit](https://cs.android.com/android/_/android/platform/packages/modules/Bluetooth/+/e8a170fa56776c25c077f328b8d69e313cec3cee:system/stack/include/gatt_api.h;dlc=27d53fb64677b034c3544aecaa954d6c21efeab4) where google engineers did this amazing change

