### PR TITLE
Fixed CharacteristicLongWriteOperation defaults

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ConnectionComponent.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ConnectionComponent.java
@@ -21,6 +21,7 @@ public interface ConnectionComponent {
     class NamedInts {
         static final String GATT_WRITE_MTU_OVERHEAD = "GATT_WRITE_MTU_OVERHEAD";
         static final String GATT_MTU_MINIMUM = "GATT_MTU_MINIMUM";
+        static final String GATT_MAX_ATTR_LENGTH = "GATT_MAX_ATTR_LENGTH";
         private NamedInts() { }
     }
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ConnectionModule.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ConnectionModule.java
@@ -22,11 +22,17 @@ import bleshadow.javax.inject.Provider;
 import io.reactivex.Scheduler;
 
 import static com.polidea.rxandroidble2.internal.connection.ConnectionComponent.NamedBooleans.SUPPRESS_OPERATION_CHECKS;
+import static com.polidea.rxandroidble2.internal.connection.ConnectionComponent.NamedInts.GATT_MAX_ATTR_LENGTH;
 import static com.polidea.rxandroidble2.internal.connection.ConnectionComponent.NamedInts.GATT_MTU_MINIMUM;
 import static com.polidea.rxandroidble2.internal.connection.ConnectionComponent.NamedInts.GATT_WRITE_MTU_OVERHEAD;
 
 @Module
 public abstract class ConnectionModule {
+
+    /** {@see https://issuetracker.google.com/issues/307234027} */
+    private static final int GATT_MAX_ATTRIBUTE_LENGTH = 600;
+    /** {@see https://issuetracker.google.com/issues/307234027} */
+    private static final int GATT_MAX_ATTRIBUTE_LENGTH_API_33 = 512;
 
     public static final String OPERATION_TIMEOUT = "operation-timeout";
 
@@ -73,6 +79,15 @@ public abstract class ConnectionModule {
     @Named(GATT_MTU_MINIMUM)
     static int minimumMtu() {
         return RxBleConnection.GATT_MTU_MINIMUM;
+    }
+
+    @Provides
+    @Named(GATT_MAX_ATTR_LENGTH)
+    static int maxAttributeLength(@Named(ClientComponent.PlatformConstants.INT_DEVICE_SDK) int deviceSdk) {
+        if (deviceSdk >= 33 /* Build.VERSION_CODES.TIRAMISU / Android 13 */) {
+            return GATT_MAX_ATTRIBUTE_LENGTH_API_33;
+        }
+        return GATT_MAX_ATTRIBUTE_LENGTH;
     }
 
     @Provides

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/MtuBasedPayloadSizeLimit.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/MtuBasedPayloadSizeLimit.java
@@ -14,16 +14,21 @@ class MtuBasedPayloadSizeLimit implements PayloadSizeLimitProvider {
 
     private final RxBleConnection rxBleConnection;
     private final int gattWriteMtuOverhead;
+    private final int maxAttributeLength;
 
     @Inject
     MtuBasedPayloadSizeLimit(RxBleConnection rxBleConnection,
-                             @Named(ConnectionComponent.NamedInts.GATT_WRITE_MTU_OVERHEAD) int gattWriteMtuOverhead) {
+                             @Named(ConnectionComponent.NamedInts.GATT_WRITE_MTU_OVERHEAD) int gattWriteMtuOverhead,
+                             @Named(ConnectionComponent.NamedInts.GATT_MAX_ATTR_LENGTH) int maxAttributeLength) {
         this.rxBleConnection = rxBleConnection;
         this.gattWriteMtuOverhead = gattWriteMtuOverhead;
+        this.maxAttributeLength = maxAttributeLength;
     }
 
     @Override
     public int getPayloadSizeLimit() {
-        return rxBleConnection.getMtu() - gattWriteMtuOverhead;
+        int maxWritePayloadForMtu = rxBleConnection.getMtu() - gattWriteMtuOverhead;
+        // See https://issuetracker.google.com/issues/307234027}
+        return Math.min(maxWritePayloadForMtu, maxAttributeLength);
     }
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/MtuBasedPayloadSizeLimitTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/MtuBasedPayloadSizeLimitTest.groovy
@@ -11,23 +11,25 @@ class MtuBasedPayloadSizeLimitTest extends Specification {
 
     MtuBasedPayloadSizeLimit objectUnderTest
 
-    private void prepareObjectUnderTest(int gattWriteMtuOverhead) {
-        objectUnderTest = new MtuBasedPayloadSizeLimit(mockBleConnection, gattWriteMtuOverhead)
+    private void prepareObjectUnderTest(int gattWriteMtuOverhead, int maxAttributeLength) {
+        objectUnderTest = new MtuBasedPayloadSizeLimit(mockBleConnection, gattWriteMtuOverhead, maxAttributeLength)
     }
 
     @Unroll
-    def "should return current MTU decreased by the write MTU overhead"() {
+    def "should return current MTU decreased by the write MTU overhead but no more than the maxAttributeLength"() {
 
         given:
-        prepareObjectUnderTest(gattWriteMtuOverhead)
+        prepareObjectUnderTest(gattWriteMtuOverhead, maxAttributeLength)
         mockBleConnection.getMtu() >> currentMtu
 
         expect:
         objectUnderTest.getPayloadSizeLimit() == expectedValue
 
         where:
-        currentMtu | gattWriteMtuOverhead | expectedValue
-        10         | 2                    | 8
-        2000       | 32                   | 1968
+        currentMtu | gattWriteMtuOverhead | maxAttributeLength | expectedValue
+        10         | 2                    | 2000               | 8
+        2000       | 32                   | 2000               | 1968
+        10         | 2                    | 512                | 8
+        2000       | 32                   | 512                | 512
     }
 }


### PR DESCRIPTION
On Android 13 when negotiated MTU > 515, CharacteristicLongWriteOperation would by default split data into chunks that did not fit Android internal data buffer for BLE writes. Reason for that is that on Android 13 the maximum attribute data buffer length was reduced from 600 to 512 bytes - which is now according to BLE Specs. Android 14 makes MTU negotiation to the maximum supported value on Android (517) by default, making this problem more likely to surface.

Fixes #843 